### PR TITLE
Add `sort` functionality

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -57,6 +57,7 @@ module.exports = (function () {
           connection.sobject(collectionName)
             .select(Object.keys(collection.definition))
             .where(options.where)
+            .sort(options.sort)
             .limit(options.limit)
             .offset(options.skip)
             .execute(function(err, results) {


### PR DESCRIPTION
This PR adds the ability to sort. To sort, the adapter now takes `{sort: {AttributeName: 1}}`. 

cc: @Samrudhi 
