### PR TITLE
Refactor adapter to use event-drivin query style

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -52,18 +52,28 @@ module.exports = (function () {
       options.where = queryShim(options.where, collectionName)
 
       spawnConnection(connectionName)
-        // Execute logic
-        .then(function (connection) {
+        .then(function(connection) {
+          var results = []
           connection.sobject(collectionName)
-            .select(Object.keys(collection.definition))
+            .select(_.keys(collection.definition))
             .where(options.where)
-            .sort(options.sort)
             .limit(options.limit)
-            .offset(options.skip)
-            .execute(function(err, results) {
-              if (err) return cb(err.toString())
+            .skip(options.skip)
+            .on('record', function(record) {
+              results.push(record)
+            })
+            .on('end', function(query) {
+              sails.log.silly('Total in database: ' + query.totalSize)
+              sails.log.silly('Total fetched: ' + query.totalFetched)
+              console.log(results.length)
               cb(null, results)
             })
+            .on('error', function(err) {
+              console.dir(err)
+            })
+            // TODO: Move these to a default config that can be overridden by
+            // the connection config within the app.
+            .execute({autoFetch: true, maxFetch: 4000})
         })
     },
 


### PR DESCRIPTION
This commit addresses the issue which was causing a limited set of results to
be returned for queries which returned greater than 200 records. The
`autofetch` option will continue to fetch records from salesforce until
`maxRecords` has been reached. However, this option is only supported when
using the event-drivin style within jsforce.

cc: @Samrudhi, @manojt100
