### PR TITLE
Add `native` function to adapter

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -114,6 +114,17 @@ module.exports = (function () {
         })
     },
 
+    native: function(connectionName, collectionName, cb) {
+      log.verbose('Spawning native connection for ' + collectionName)
+
+      spawnConnection(connectionName)
+        .then(function(connection) {
+          cb(null, connection.sobject(collectionName))
+        })
+        .fail(cb)
+        .done()
+    },
+
     // TODO: Implement teardown process.
     teardown: function(connectionName, cb) { cb() },
     // TODO: Implement `Model.define()` functionality.


### PR DESCRIPTION
This commit adds a `native` function within the adapter that will
return a Salesforce connection object initialized for the current
collection.

cc: @manojt100 
