### PR TITLE
Fix process hang for `find` errors

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -68,7 +68,8 @@ module.exports = (function () {
               cb(null, results)
             })
             .on('error', function(err) {
-              console.dir(err)
+              log.error(err.toString())
+              cb(err.toString())
             })
             // TODO: Move these to a default config that can be overridden by
             // the connection config within the app.


### PR DESCRIPTION
Fixes #7 

This PR fixes the issue where the entire app process could hang if any error occurred during the find operation. To test, you just need to issue a malformed `GET` request. The easiest way is to modify the `targetId` of any details page that relies on SFDC as it's datastore.

@Samrudhi, can you review this since I think you are the only one who fully knows how to test adapter changes? 
