### PR TITLE
Add initial `parseCriteria` helper

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -58,6 +58,7 @@ module.exports = (function () {
           connection.sobject(collectionName)
             .select(_.keys(collection.definition))
             .where(options.where)
+            .sort(options.sort)
             .limit(options.limit)
             .skip(options.skip)
             .on('record', function(record) {


### PR DESCRIPTION
This commit adds a basic `parseCriteria` helper method to enable
useage of the `or` operator from the waterline criteria
specification.

cc: @manojt100 
SR-650
