### PR TITLE
Fix broken query response

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -82,9 +82,7 @@ module.exports = (function () {
             .on('record', function(record) {
               results.push(record)
             })
-            .on('end', function(query) {
-              sails.log.silly('Total in database: ' + query.totalSize)
-              sails.log.silly('Total fetched: ' + query.totalFetched)
+            .on('end', function() {
               cb(null, results)
             })
             .on('error', function(err) {


### PR DESCRIPTION
This commit fixes an issue caused by a regression in the jsforce
library where the query metadata is no longer returned to the
callback attached to the "end" event.
See https://github.com/jsforce/jsforce/issues/265
