### PR TITLE
Bump maxfetch to 10000

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -65,8 +65,6 @@ module.exports = (function () {
               results.push(record)
             })
             .on('end', function(query) {
-              sails.log.silly('Total in database: ' + query.totalSize)
-              sails.log.silly('Total fetched: ' + query.totalFetched)
               cb(null, results)
             })
             .on('error', function(err) {
@@ -75,7 +73,7 @@ module.exports = (function () {
             })
             // TODO: Move these to a default config that can be overridden by
             // the connection config within the app.
-            .execute({autoFetch: true, maxFetch: 4000})
+            .execute({autoFetch: true, maxFetch: 10000})
         })
     },
 


### PR DESCRIPTION
This commit bumps the match fetch value to 10,000 to support the
larger number of licenses on the Nutanix Corporate account.