### PR TITLE
Counting any model SFDC records with given context

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -44,6 +44,24 @@ module.exports = (function () {
         .fail(cb)
     },
 
+    count: function(connectionName, collectionName, options, cb) {
+      log.verbose('counting ' + collectionName)
+      var collection = connections[connectionName].collections[collectionName]
+
+      // Shim in required query params and parse any logical operators.
+      options.where = queryShim(options.where, collectionName)
+      options.where = parseClause(options.where)
+
+      spawnConnection(connectionName)
+        .then(function(connection) {
+          connection.sobject(collectionName)
+            .count(function(){
+              cb(arguments[0], arguments[1])
+            }
+          ).where(options.where)
+      })
+    },
+
     find: function(connectionName, collectionName, options, cb) {
       log.verbose('finding ' + collectionName)
       var collection = connections[connectionName].collections[collectionName]


### PR DESCRIPTION
Without count method, it gets the count from find method which is
time-consuming(May be it takes a min to fetch the SFDC model count with find method)