### PR TITLE
Add ability to retrieve an Apex REST connection

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -146,6 +146,16 @@ module.exports = (function () {
         .done()
     },
 
+    // Return an Apex REST connection.
+    apex: function(connectionName, collectioName, cb) {
+      spawnConnection(connectionName)
+        .then(function(connection) {
+          cb(null, connection.apex);
+        })
+        .fail(cb)
+        .done();
+    },
+
     // TODO: Implement teardown process.
     teardown: function(connectionName, cb) { cb() },
     // TODO: Implement `Model.define()` functionality.


### PR DESCRIPTION
This commit updates the Salesforce adapter to support returning a
connection with access to Apex REST endpoints. It will allow us to
hit any custom APIs that are developed on the Salesforce
platform.

@see https://jsforce.github.io/document/#apex-rest