### PR TITLE
Add "runLocal" flag to the connection config

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -202,6 +202,15 @@ module.exports = (function () {
 
       // Otherwise, spawn a fresh connection.
       connection = new jsforce.Connection(config.connectionParams)
+
+      // If the server instance using this adapter wants to run locally then
+      // just return the connection without connecting to Salesforce. This
+      // setting can be useful to avoid a dependency on an outbound internet
+      // connection.
+      if (config.runLocal) {
+        return resolve(connection);
+      }
+
       connection.login(config.username, config.password)
         .then(function (user) {
           log.verbose('SFDC connection spawned: ' + JSON.stringify(user))


### PR DESCRIPTION
This commit adds a "runLocal" flag to the connection config that
removes the dependency on a network connection. It's main purpose
for now is to help with CI runs but in the future could be
extended to use a local cache so developers do not require a
valid Salesforce connection to work.