### PR TITLE
Sending error object back in error callback

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -95,7 +95,7 @@ module.exports = (function () {
             })
             .on('error', function(err) {
               log.error(err.toString())
-              cb(err.toString())
+              cb(err)
             })
             // TODO: Move these to a default config that can be overridden by
             // the connection config within the app.


### PR DESCRIPTION
Sending error object in error callback, instead of a string in find method.
Newer sails expect error object form the adapter. 

Currently in case of error in adapter, since string is passed from adapter sails says 
AdapterError: Malformed error from adapter: Should always be an Error instance, but instead, got string, (ie) It is transforming one error to another error.