### PR TITLE
SAAS-13307 - Fail Safe When Salesforce Goes Down

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -284,7 +284,8 @@ module.exports = (function () {
         return resolve(connection);
       }
 
-      connection.login(config.username, config.password)
+      connection
+        .login(config.username, config.password)
         .then(function (user) {
           log.verbose('SFDC connection spawned: ' + JSON.stringify(user))
 
@@ -297,7 +298,34 @@ module.exports = (function () {
           // Return the active connection
           resolve(connection)
         })
-        .fail(reject)
+        .fail(function (err) {
+          /*
+           * Considering SFDC could have downtime (planned / unplanned) and
+           * that it might not be the only primary dependency for an app,
+           * failSafe config is to ensure the sails adapter still returns a
+           * connection object to enable successful lift of sails app with
+           * the understanding that SFDC API calls would fail during downtime
+           * and app is handling fallback / error.
+           *
+           * This is considered false by default to keep it consistent with
+           * other adapters and each app could explicitly set it to true
+           * knowing the expected functionality / impact.
+           */
+          var failSafe = config.failSafe
+
+          failSafe = (
+            (failSafe === true) ||
+            (failSafe === 'true')
+          )
+
+          log.error('SFDC connection failed: ', err)
+
+          if (failSafe) {
+            return resolve(connection)
+          }
+
+          reject(err)
+        })
     })
   }
 


### PR DESCRIPTION
- Considering Salesforce could have downtime (planned / unplanned) and that it might not be the only primary dependency for an app, introducing (optional) failSafe config to ensure the sails adapter still returns a connection object to enable successful resolution of sails hook orm and lift of sails app, with the understanding that calls to Salesforce could still fail during downtime and app is responsible for handling fallback / error.
- failSafe flag is considered false by default to keep it consistent with other adapters, and each app could explicitly set it to true knowing the expected impact / functionality.