### PR TITLE
Fix sails hook orm v4.01 upgrade issue

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -23,6 +23,9 @@ module.exports = (function () {
     },
     adapterApiVersion: 1,
 
+    // expose connections/datastores as it will used by the waterline orm version ^0.15.0 to validate datastore connection.
+    datastores: connections,
+
     registerDatastore: function(connection, collections, cb) {
       if(!connection.identity) return cb(Errors.IdentityMissing)
       if(connections[connection.identity]) return cb(Errors.IdentityDuplicate)


### PR DESCRIPTION
### Summary
Fix failure in upgrading sails-hook-orm to v4.0.1